### PR TITLE
Issue 39 login options

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,10 @@ app.use(
 app.use(session({
     secret : 'secret',
     resave : true,
-    saveUninitialized : true
+    saveUninitialized : true,
+    cookie: {
+      secure: true,
+  }
 }));
 app.use(passport.initialize());
 app.use(passport.session());

--- a/config/passport.js
+++ b/config/passport.js
@@ -4,6 +4,7 @@ const bcrypt = require('bcrypt');
 var GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
 var FacebookStrategy = require('passport-facebook');
 var TwitterStrategy = require('passport-twitter');
+var GithubStrategy = require('passport-github2');
 
 
 module.exports = function(passport){
@@ -117,6 +118,44 @@ module.exports = function(passport){
         consumerKey        : process.env.apikey_twitter,
         consumerSecret    : process.env.apisecret_twitter,
         callbackURL     : 'http://127.0.0.1:3100/users/twitter/callback',
+
+    },
+    function(token, refreshToken, profile, done) {
+
+        // make the code asynchronous
+        // User.findOne won't fire until we have all our data back from Google
+        process.nextTick(function() {
+
+            // try to find the user based on their google id
+            User.findOne({ email : profile.id }, function(err, user) {
+                if (err)
+                    return done(err);
+
+                if (user) {
+                    // if a user is found, log them in
+                    return done(null, user);
+                } else {
+                    // user not found, so created a new one
+                    const newUser = new User({
+                        name : profile.displayName,
+                        email : profile.id,
+                        password : "somerandompasswordhere123^&^"
+                    });
+                    newUser.save()
+                    .then((value)=>{
+                        console.log(value)
+                        return done(null, user);
+                    });
+                }
+            });
+        });
+    }));
+
+    passport.use('github', new GithubStrategy({
+
+        clientID        : process.env.clientId_github,
+        clientSecret    : process.env.clientSecret_github,
+        callbackURL     : 'http://127.0.0.1:3100/users/github/callback',
 
     },
     function(token, refreshToken, profile, done) {

--- a/config/passport.js
+++ b/config/passport.js
@@ -2,6 +2,8 @@ const User = require('../models/user');
 const LocalStrategy = require('passport-local').Strategy;
 const bcrypt = require('bcrypt');
 var GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
+var FacebookStrategy = require('passport-facebook');
+var TwitterStrategy = require('passport-twitter');
 
 
 module.exports = function(passport){
@@ -36,8 +38,8 @@ module.exports = function(passport){
     })
     passport.use('google', new GoogleStrategy({
 
-        clientID        : process.env.clientId,
-        clientSecret    : process.env.clientSecret,
+        clientID        : process.env.clientId_google,
+        clientSecret    : process.env.clientSecret_google,
         callbackURL     : 'http://127.0.0.1:3100/users/google/callback',
 
     },
@@ -71,5 +73,80 @@ module.exports = function(passport){
             });
         });
 
+    }));
+    passport.use('facebook', new FacebookStrategy({
+
+        clientID        : process.env.clientId_facebook,
+        clientSecret    : process.env.clientSecret_facebook,
+        callbackURL     : 'http://127.0.0.1:3100/users/facebook/callback',
+
+    },
+    function(token, refreshToken, profile, done) {
+
+        // make the code asynchronous
+        // User.findOne won't fire until we have all our data back from Google
+        process.nextTick(function() {
+
+            // try to find the user based on their google id
+            User.findOne({ email : profile.id }, function(err, user) {
+                if (err)
+                    return done(err);
+
+                if (user) {
+                    // if a user is found, log them in
+                    return done(null, user);
+                } else {
+                    // user not found, so created a new one
+                    const newUser = new User({
+                        name : profile.displayName,
+                        email : profile.id,
+                        password : "somerandompasswordhere123^&^"
+                    });
+                    newUser.save()
+                    .then((value)=>{
+                        console.log(value)
+                        return done(null, user);
+                    });
+                }
+            });
+        });
+    }));
+
+    passport.use('twitter', new TwitterStrategy({
+
+        consumerKey        : process.env.apikey_twitter,
+        consumerSecret    : process.env.apisecret_twitter,
+        callbackURL     : 'http://127.0.0.1:3100/users/twitter/callback',
+
+    },
+    function(token, refreshToken, profile, done) {
+
+        // make the code asynchronous
+        // User.findOne won't fire until we have all our data back from Google
+        process.nextTick(function() {
+
+            // try to find the user based on their google id
+            User.findOne({ email : profile.id }, function(err, user) {
+                if (err)
+                    return done(err);
+
+                if (user) {
+                    // if a user is found, log them in
+                    return done(null, user);
+                } else {
+                    // user not found, so created a new one
+                    const newUser = new User({
+                        name : profile.displayName,
+                        email : profile.id,
+                        password : "somerandompasswordhere123^&^"
+                    });
+                    newUser.save()
+                    .then((value)=>{
+                        console.log(value)
+                        return done(null, user);
+                    });
+                }
+            });
+        });
     }));
 }

--- a/config/passport.js
+++ b/config/passport.js
@@ -5,6 +5,7 @@ var GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
 var FacebookStrategy = require('passport-facebook');
 var TwitterStrategy = require('passport-twitter');
 var GithubStrategy = require('passport-github2');
+var DiscordStrategy = require('passport-discord').Strategy;
 
 
 module.exports = function(passport){
@@ -176,6 +177,46 @@ module.exports = function(passport){
                     // user not found, so created a new one
                     const newUser = new User({
                         name : profile.displayName,
+                        email : profile.id,
+                        password : "somerandompasswordhere123^&^"
+                    });
+                    newUser.save()
+                    .then((value)=>{
+                        console.log(value)
+                        return done(null, user);
+                    });
+                }
+            });
+        });
+    }));
+
+    passport.use('discord', new DiscordStrategy({
+
+        clientID        : process.env.clientId_discord,
+        clientSecret    : process.env.clientSecret_discord,
+        callbackURL     : 'http://127.0.0.1:3100/users/discord/callback',
+        scope          : ['identify']
+
+    },
+    function(token, refreshToken, profile, done) {
+
+        // make the code asynchronous
+        // User.findOne won't fire until we have all our data back from Google
+        process.nextTick(function() {
+            console.log(profile);
+
+            // try to find the user based on their google id
+            User.findOne({ email : profile.id }, function(err, user) {
+                if (err)
+                    return done(err);
+
+                if (user) {
+                    // if a user is found, log them in
+                    return done(null, user);
+                } else {
+                    // user not found, so created a new one
+                    const newUser = new User({
+                        name : profile.username,
                         email : profile.id,
                         password : "somerandompasswordhere123^&^"
                     });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "multer": "^1.4.3",
     "node-site-downloader": "^1.3.0",
     "passport": "^0.5.0",
+    "passport-discord": "^0.1.4",
     "passport-facebook": "^3.0.0",
     "passport-github2": "^0.1.12",
     "passport-google-oauth": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "node-site-downloader": "^1.3.0",
     "passport": "^0.5.0",
     "passport-facebook": "^3.0.0",
+    "passport-github2": "^0.1.12",
     "passport-google-oauth": "^2.0.0",
     "passport-local": "^1.0.0",
     "passport-twitter": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,15 @@
   "description": "A portfolio website generator.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/harshagrawal523/Portfolyser.git"
+  },
+  "engines": {
+    "node": "16.13.1"
   },
   "author": "",
   "license": "ISC",
@@ -33,8 +37,10 @@
     "multer": "^1.4.3",
     "node-site-downloader": "^1.3.0",
     "passport": "^0.5.0",
+    "passport-facebook": "^3.0.0",
     "passport-google-oauth": "^2.0.0",
     "passport-local": "^1.0.0",
+    "passport-twitter": "^1.0.4",
     "path": "^0.12.7",
     "website-scraper": "^4.2.3"
   }

--- a/routes/users.js
+++ b/routes/users.js
@@ -36,6 +36,12 @@ router.get('/github/callback',
                 successRedirect : '/',
                 failureRedirect : '/users/login'
             }));
+router.get('/discord', passport.authenticate('discord'));
+router.get('/discord/callback',
+            passport.authenticate('discord', {
+                successRedirect : '/',
+                failureRedirect : '/users/login'
+            }));
 //Register handle
 router.post('/login',(req,res,next)=>{
 passport.authenticate('local',{

--- a/routes/users.js
+++ b/routes/users.js
@@ -17,6 +17,19 @@ router.get('/google/callback',
                     successRedirect : '/',
                     failureRedirect : '/users/login'
             }));
+//Facebook
+router.get('/facebook', passport.authenticate('facebook'));
+router.get('/facebook/callback',
+            passport.authenticate('facebook', {
+                successRedirect : '/',
+                failureRedirect : '/users/login'
+            }));
+router.get('/twitter', passport.authenticate('twitter'));
+router.get('/twitter/callback',
+            passport.authenticate('twitter', {
+                successRedirect : '/',
+                failureRedirect : '/users/login'
+            }));
 //Register handle
 router.post('/login',(req,res,next)=>{
 passport.authenticate('local',{

--- a/routes/users.js
+++ b/routes/users.js
@@ -30,6 +30,12 @@ router.get('/twitter/callback',
                 successRedirect : '/',
                 failureRedirect : '/users/login'
             }));
+router.get('/github', passport.authenticate('github'));
+router.get('/github/callback',
+            passport.authenticate('github', {
+                successRedirect : '/',
+                failureRedirect : '/users/login'
+            }));
 //Register handle
 router.post('/login',(req,res,next)=>{
 passport.authenticate('local',{

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -127,10 +127,32 @@
     text-decoration: none;
     color: #17b4a1;
   }
+  .signin-with-facebook{
+    text-align: center;
+    text-decoration: none;
+    color: #17b4a1;
+  }
+  .signin-with-twitter{
+    text-align: center;
+    text-decoration: none;
+    color: #17b4a1;
+  }
   a{
     color:#17b4a1;
   }
   .google{
+    margin-top: -1rem;
+    color:rgb(0, 143, 209);
+    font-weight: 600;
+    margin-bottom: 2rem;
+  }
+  .facebook{
+    margin-top: -1rem;
+    color:rgb(0, 143, 209);
+    font-weight: 600;
+    margin-bottom: 2rem;
+  }
+  .twitter{
     margin-top: -1rem;
     color:rgb(0, 143, 209);
     font-weight: 600;
@@ -195,6 +217,8 @@
 </form>
 <p class="login-link">Don't Have An Account? <a href="/users/register">Register</a></p>
 <a href="/users/google" class="signin-with-google"><p class="google">Sign in with Google</p></a>
+<a href="/users/facebook" class="signin-with-facebook"><p class="facebook">Sign in with Facebook</p></a>
+<a href="/users/twitter" class="signin-with-twitter"><p class="twitter">Sign in with Twitter</p></a>
 </div>
 </div>
 </body>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -198,6 +198,7 @@
 <a href="/users/facebook" class="signin-with"><p class="company">Sign in with Facebook</p></a>
 <a href="/users/twitter" class="signin-with"><p class="company">Sign in with Twitter</p></a>
 <a href="/users/github" class="signin-with"><p class="company">Sign in with Github</p></a>
+<a href="/users/discord" class="signin-with"><p class="company">Sign in with Discord</p></a>
 </div>
 </div>
 </body>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -122,17 +122,7 @@
       margin-bottom: 0rem;
      }
   }
-  .signin-with-google{
-    text-align: center;
-    text-decoration: none;
-    color: #17b4a1;
-  }
-  .signin-with-facebook{
-    text-align: center;
-    text-decoration: none;
-    color: #17b4a1;
-  }
-  .signin-with-twitter{
+  .signin-with{
     text-align: center;
     text-decoration: none;
     color: #17b4a1;
@@ -140,19 +130,7 @@
   a{
     color:#17b4a1;
   }
-  .google{
-    margin-top: -1rem;
-    color:rgb(0, 143, 209);
-    font-weight: 600;
-    margin-bottom: 2rem;
-  }
-  .facebook{
-    margin-top: -1rem;
-    color:rgb(0, 143, 209);
-    font-weight: 600;
-    margin-bottom: 2rem;
-  }
-  .twitter{
+  .company{
     margin-top: -1rem;
     color:rgb(0, 143, 209);
     font-weight: 600;
@@ -216,9 +194,10 @@
   </div>
 </form>
 <p class="login-link">Don't Have An Account? <a href="/users/register">Register</a></p>
-<a href="/users/google" class="signin-with-google"><p class="google">Sign in with Google</p></a>
-<a href="/users/facebook" class="signin-with-facebook"><p class="facebook">Sign in with Facebook</p></a>
-<a href="/users/twitter" class="signin-with-twitter"><p class="twitter">Sign in with Twitter</p></a>
+<a href="/users/google" class="signin-with"><p class="company">Sign in with Google</p></a>
+<a href="/users/facebook" class="signin-with"><p class="company">Sign in with Facebook</p></a>
+<a href="/users/twitter" class="signin-with"><p class="company">Sign in with Twitter</p></a>
+<a href="/users/github" class="signin-with"><p class="company">Sign in with Github</p></a>
 </div>
 </div>
 </body>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -122,7 +122,7 @@
       margin-bottom: 0rem;
      }
   }
-  .signin-with-google{
+  .signin-with{
     text-align: center;
     text-decoration: none;
     color: #17b4a1;
@@ -130,7 +130,7 @@
   a{
     color:#17b4a1;
   }
-  .google{
+  .company{
     margin-top: -1rem;
     color:rgb(0, 143, 209);
     font-weight: 600;
@@ -213,7 +213,11 @@
   </div>
 </form>
 <p class="login-link">Have An Account? <a href="/users/login">Login</a></p>
-<a href="/users/google" class="signin-with-google"><p class="google">Sign in with Google</p></a>
+<a href="/users/google" class="signin-with"><p class="company">Sign in with Google</p></a>
+<a href="/users/facebook" class="signin-with"><p class="company">Sign in with Facebook</p></a>
+<a href="/users/twitter" class="signin-with"><p class="company">Sign in with Twitter</p></a>
+<a href="/users/github" class="signin-with"><p class="company">Sign in with Github</p></a>
+<a href="/users/discord" class="signin-with"><p class="company">Sign in with Discord</p></a>
 </div>
 </div>
 </body>


### PR DESCRIPTION
Closes #39.

I have implemented Facebook, Twitter, Github, and Discord OAuth options.

You will need these keys before testing the application, add them in your `config/config.env` folder.

    PORT = 3100
    MONGO_URI= 
    clientId_google = 
    clientSecret_google = 
    clientId_facebook = 
    clientSecret_facebook = 
    apikey_twitter = 
    apisecret_twitter = 
    clientId_github = 
    clientSecret_github = 
    clientId_discord = 
    clientSecret_discord = 

Callback URLs are like Google's, just replace google with the respective option.
Also, in Twitter, you have to use OAuth 1.0a, and request elevated access.

And, you won't be able to test Facebook Login while working on localhost, as it doesn't allow the callback URL to be an HTTP link. It only works for HTTPS.

To ease the review process, I have deployed the app on Heroku: https://portfolyser.herokuapp.com/
Facebook login will work on Heroku app, as it uses HTTPS.

If you are also reviewing the application by deploying it to some hosting service, make sure to change callback URLs in all the developer consoles, and also in `passport.js`.